### PR TITLE
Set link color to match accent color

### DIFF
--- a/_extensions/classic-cv/template.tex
+++ b/_extensions/classic-cv/template.tex
@@ -63,7 +63,7 @@
 
 \usepackage{fancyhdr}				
 \pagestyle{fancy}
-\usepackage[colorlinks]{hyperref}
+\usepackage[colorlinks, allcolors=sectcol]{hyperref}
 %less space between header and content
 \setlength{\headheight}{-5pt}		
 


### PR DESCRIPTION
Thanks for this template, really makes my life easier :)

I started adding links to my resume, and they came out pink. I wanted them to match the accent color, hence this change.

I'm not very skilled with LaTeX, so I hope I am at least in the right ballpark!